### PR TITLE
Avoid nulls in the JSHint errors array.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,10 @@ JSHinter.prototype.processErrors = function (file, errors) {
 
   for (idx=0; idx<len; idx++) {
     error = errors[idx];
-    str += file  + ': line ' + error.line + ', col ' +
-      error.character + ', ' + error.reason + '\n';
+    if (error !== null) {
+      str += file  + ': line ' + error.line + ', col ' +
+        error.character + ', ' + error.reason + '\n';
+    }
   }
 
   return str + "\n" + len + ' error' + ((len === 1) ? '' : 's');

--- a/tests/fixtures/some-files-with-too-many-errors/.jshintrc
+++ b/tests/fixtures/some-files-with-too-many-errors/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "asi": false,
+  "maxerr": 5
+}

--- a/tests/fixtures/some-files-with-too-many-errors/tons-o-errors.js
+++ b/tests/fixtures/some-files-with-too-many-errors/tons-o-errors.js
@@ -1,0 +1,5 @@
+var foo = 'bar'
+var foo = 'bar'
+var foo = 'bar'
+var foo = 'bar'
+var foo = 'bar'

--- a/tests/index.js
+++ b/tests/index.js
@@ -71,6 +71,21 @@ describe('broccoli-jshint', function(){
       });
     });
 
+    it('can handle too many errors', function(){
+      var sourcePath = 'tests/fixtures/some-files-with-too-many-errors';
+      chdir(sourcePath);
+
+      var tree = jshintTree('.', {
+        destFile: 'jshint-tests.js',
+        logError: function(message) { loggerOutput.push(message) }
+      });
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(dir) {
+        expect(loggerOutput.join('\n')).to.match(/Too many errors./)
+      });
+    });
+
     it('can handle jshintrc if it has comments', function(){
       var sourcePath = 'tests/fixtures/comments-in-jshintrc';
       chdir(sourcePath);


### PR DESCRIPTION
When JSHint encounters and internal error (eg `Too many errors`), it pushes a null into the errors array.

https://github.com/jshint/jshint/blob/2.x/src/jshint.js#L4902

This causes `TypeError: Cannot read property 'line' of null` to be thrown.  
