### PR TITLE
Fixed an issue where globals weren't being picked up

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,11 @@ JSHinter.prototype.write = function (readTree, destDir) {
 }
 
 JSHinter.prototype.processString = function (content, relativePath) {
-  var passed = JSHINT(content, this.jshintrc);
+
+  var globals = this.jshintrc.globals;
+  delete(this.jshintrc.globals);
+
+  var passed = JSHINT(content, this.jshintrc, globals);
   var errors = this.processErrors(relativePath, JSHINT.errors);
 
   if (!passed && this.log) {


### PR DESCRIPTION
I noticed that when I was using this module the global options I had set up in my `.jshintrc` file were not being picked up by `jshint`. According to [this comment](https://github.com/jshint/jshint/issues/710#issuecomment-15539466) the globals need to be passed in as the third parameter when calling `jshint`, so I've amended the `index.js` to reflect this.

Note that `jshint` seemed to work better when the globals were removed from `.jshintrc` than if they were left in which is why line 53 is there (otherwise I would have left it out).
