### PR TITLE
Bump jshint to 2.6.2 for tagged template support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "javascript"
   ],
   "dependencies": {
-    "jshint": "~2.5.0",
+    "jshint": "~2.6.2",
     "chalk": "~0.4.0",
     "broccoli-filter": "~0.1.11",
     "findup-sync": "~0.1.3",


### PR DESCRIPTION
See: https://github.com/jshint/jshint/releases/tag/2.6.1 :)