### PR TITLE
Switches `module` to `QUnit.module`

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,8 +89,8 @@ JSHinter.prototype.testGenerator = function(relativePath, passed, errors) {
   }
 
   return "QUnit.module('JSHint - " + path.dirname(relativePath) + "');\n" +
-         "test('" + relativePath + " should pass jshint', function() { \n" +
-         "  ok(" + !!passed + ", '" + relativePath + " should pass jshint." + errors + "'); \n" +
+         "QUnit.test('" + relativePath + " should pass jshint', function(assert) { \n" +
+         "  assert.ok(" + !!passed + ", '" + relativePath + " should pass jshint." + errors + "'); \n" +
          "});\n"
 };
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ JSHinter.prototype.testGenerator = function(relativePath, passed, errors) {
     errors = ""
   }
 
-  return "module('JSHint - " + path.dirname(relativePath) + "');\n" +
+  return "QUnit.module('JSHint - " + path.dirname(relativePath) + "');\n" +
          "test('" + relativePath + " should pass jshint', function() { \n" +
          "  ok(" + !!passed + ", '" + relativePath + " should pass jshint." + errors + "'); \n" +
          "});\n"


### PR DESCRIPTION
According to http://qunitjs.com/upgrade-guide-2.x/ `module` will be removed from the global scope.

This was also causing me issues where this use of `module` was somehow conflicting with https://github.com/ModuleLoader/es6-module-loader and/or https://github.com/systemjs/systemjs