### PR TITLE
Disabling test generation should not create files

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ JSHinter.prototype.write = function (readTree, destDir) {
       var jshintPath = self.jshintrcPath || path.join(srcDir, self.jshintrcRoot || '');
       self.jshintrc = self.getConfig(jshintPath);
     }
-    return Filter.prototype.write.call(self, readTree, destDir)
+    if (!self.disableTestGenerator) {
+      return Filter.prototype.write.call(self, readTree, destDir)
+    }
   })
   .finally(function() {
     if (self._errors.length > 0) {


### PR DESCRIPTION
Without this change, blank files are generated (not really blank but containing the string "undefined"). Moreover, the file generation process is slow and does not make sense for empty files.