### PR TITLE
bump findup-sync version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "broccoli-persistent-filter": "^1.0.3",
     "chalk": "~0.4.0",
-    "findup-sync": "~0.1.3",
+    "findup-sync": "^0.3.0",
     "jshint": "^2.7.0",
     "json-stable-stringify": "^1.0.0",
     "mkdirp": "~0.4.0"


### PR DESCRIPTION
gets rid of a lodash deprecation warning