### PR TITLE
Remove unused "rimraf" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "mocha": "~1.18.2",
     "broccoli": "~0.13.0",
-    "expect.js": "~0.3.1",
-    "rimraf": "~2.2.6"
+    "expect.js": "~0.3.1"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,7 +3,6 @@
 var path = require('path');
 var JSHinter = require('..');
 var expect = require('expect.js');
-var rimraf = require('rimraf');
 var root = process.cwd();
 var chalk = require('chalk');
 


### PR DESCRIPTION
This package seems to be unused in `tests/index.js` so we might as well remove it