### PR TITLE
Change file extension to more generic "lint.js"

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function JSHinter (inputNode, options) {
 };
 
 JSHinter.prototype.extensions = ['js'];
-JSHinter.prototype.targetExtension = 'jshint.js';
+JSHinter.prototype.targetExtension = 'lint.js';
 
 JSHinter.prototype.baseDir = function() {
   return __dirname;

--- a/tests/index.js
+++ b/tests/index.js
@@ -193,9 +193,9 @@ describe('broccoli-jshint', function(){
       return builder.build().then(function(results) {
         var dir = results.directory;
 
-        expect(readFile(dir + '/core.jshint.js')).to.match(/Missing semicolon./)
+        expect(readFile(dir + '/core.lint.js')).to.match(/Missing semicolon./)
 
-        expect(readFile(dir + '/look-no-errors.jshint.js')).to.match(/ok\(true, 'look-no-errors.js should pass jshint.'\);/)
+        expect(readFile(dir + '/look-no-errors.lint.js')).to.match(/ok\(true, 'look-no-errors.js should pass jshint.'\);/)
       });
     });
 
@@ -218,7 +218,7 @@ describe('broccoli-jshint', function(){
         var dir = results.directory;
 
         expect(escapeErrorStringCalled).to.be.ok();
-        expect(readFile(dir + '/core.jshint.js')).to.match(/blazhorz/)
+        expect(readFile(dir + '/core.lint.js')).to.match(/blazhorz/)
       });
     });
 
@@ -234,9 +234,9 @@ describe('broccoli-jshint', function(){
       return builder.build().then(function(results) {
         var dir = results.directory;
 
-        expect(readFile(dir + '/core.jshint.js')).to.not.match(/Missing semicolon./)
+        expect(readFile(dir + '/core.lint.js')).to.not.match(/Missing semicolon./)
 
-        expect(readFile(dir + '/look-no-errors.jshint.js')).to.not.match(/ok\(true, 'look-no-errors.js should pass jshint.'\);/)
+        expect(readFile(dir + '/look-no-errors.lint.js')).to.not.match(/ok\(true, 'look-no-errors.js should pass jshint.'\);/)
       });
     });
   });


### PR DESCRIPTION
Gearing up to make ember-cli-qunit linting less specific to JSHint. Needs to be coordinated with PR from ember-cli-qunit.