### PR TITLE
Change test extension to `.lint-test.js`

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function JSHinter (inputNode, options) {
 }
 
 JSHinter.prototype.extensions = ['js'];
-JSHinter.prototype.targetExtension = 'lint.js';
+JSHinter.prototype.targetExtension = 'lint-test.js';
 
 JSHinter.prototype.baseDir = function() {
   return __dirname;

--- a/tests/index.js
+++ b/tests/index.js
@@ -145,7 +145,7 @@ describe('broccoli-jshint', function(){
       builder = new broccoli.Builder(node);
       return builder.build().then(function() {
         var expected = [
-          '\n' + chalk.red('core.js: line 1, col 20, Missing semicolon.\n\n1 error') + '\n\n' + chalk.red('main.js: line 1, col 1, Missing semicolon.\n\n1 error') + '\n',
+          '\n' + chalk.red('core.js: line 1, col 20, Missing semicolon.\n\n1 error') + '\n\n' + chalk.red('main.js: line 1, col 10, Missing semicolon.\n\n1 error') + '\n',
           chalk.yellow('===== 2 JSHint Errors\n')
         ]
         expect(consoleLogOutput).to.eql(expected);
@@ -193,9 +193,9 @@ describe('broccoli-jshint', function(){
       return builder.build().then(function(results) {
         var dir = results.directory;
 
-        expect(readFile(dir + '/core.lint.js')).to.match(/Missing semicolon./)
+        expect(readFile(dir + '/core.lint-test.js')).to.match(/Missing semicolon./)
 
-        expect(readFile(dir + '/look-no-errors.lint.js')).to.match(/ok\(true, 'look-no-errors.js should pass jshint.'\);/)
+        expect(readFile(dir + '/look-no-errors.lint-test.js')).to.match(/ok\(true, 'look-no-errors.js should pass jshint.'\);/)
       });
     });
 
@@ -218,7 +218,7 @@ describe('broccoli-jshint', function(){
         var dir = results.directory;
 
         expect(escapeErrorStringCalled).to.be.ok;
-        expect(readFile(dir + '/core.lint.js')).to.match(/blazhorz/)
+        expect(readFile(dir + '/core.lint-test.js')).to.match(/blazhorz/)
       });
     });
 
@@ -234,9 +234,9 @@ describe('broccoli-jshint', function(){
       return builder.build().then(function(results) {
         var dir = results.directory;
 
-        expect(readFile(dir + '/core.lint.js')).to.not.match(/Missing semicolon./)
+        expect(readFile(dir + '/core.lint-test.js')).to.not.match(/Missing semicolon./)
 
-        expect(readFile(dir + '/look-no-errors.lint.js')).to.not.match(/ok\(true, 'look-no-errors.js should pass jshint.'\);/)
+        expect(readFile(dir + '/look-no-errors.lint-test.js')).to.not.match(/ok\(true, 'look-no-errors.js should pass jshint.'\);/)
       });
     });
   });


### PR DESCRIPTION
This addresses https://github.com/ember-cli/ember-cli-jshint/pull/5, and is a follow up from the discussion in https://github.com/rwjblue/broccoli-jshint/pull/41.

To test these changes, I installed a new Ember CLI app, and created npm links in locally cloned repos:

```
ember-cli-app => ember-cli-jshint => broccoli-jshint
```

Now the files generated end in `.lint-test.js`, aligning with ember-cli-qunit:

![screen shot 2016-09-11 at 12 31 04 pm](https://cloud.githubusercontent.com/assets/15169/18420127/56be0312-7820-11e6-9ca0-221860996c56.png)

Running all tests show the linting tests:

![screen shot 2016-09-11 at 12 31 45 pm](https://cloud.githubusercontent.com/assets/15169/18420133/6a9bb74e-7820-11e6-84e9-4744d9c6b4bb.png)

Using the "Disable Linting" checkbox works:

![screen shot 2016-09-11 at 12 31 55 pm](https://cloud.githubusercontent.com/assets/15169/18420136/7888d288-7820-11e6-9ecf-a56b9015c262.png)

@Turbo87 could you double check that this fixes the issue? Testing this is a little involved so I would love to get a second set of eyes.
